### PR TITLE
Catch error getting URL, avoid errors on timeout (untested)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,51 +113,59 @@ export const getMediaValue = (
 ) => {
   if (series && series.length) {
     for (const item of mediaSources) {
-      const mediaItem = findField<string>(series, (field, frame) => {
-        if (item.refId) {
-          if (frame?.refId === item.refId) {
+      try {
+        const mediaItem = findField<string>(series, (field, frame) => {
+          if (item.refId) {
+            if (frame?.refId === item.refId) {
+              return field.name === item.field;
+            }
+            return false;
+          } else {
             return field.name === item.field;
           }
-          return false;
-        } else {
-          return field.name === item.field;
-        }
-      });
+        });
 
-      if (mediaItem && mediaItem?.values[currentIndex]) {
-        let currentUrl: string;
+        if (mediaItem && mediaItem?.values[currentIndex]) {
+          let currentUrl: string;
 
-        if (Base64.isValid(mediaItem.values[currentIndex])) {
-          /**
-           * Base64 format handle
-           */
-          currentUrl = handleMediaData(mediaItem?.values[currentIndex] as string).currentMedia;
+          if (Base64.isValid(mediaItem.values[currentIndex])) {
+            /**
+             * Base64 format handle
+             */
+            currentUrl = handleMediaData(mediaItem?.values[currentIndex] as string).currentMedia;
 
-          /**
-           * Handle case for PDF
-           */
-          if (item.type === MediaFormat.PDF) {
-            const blob = base64toBlob(currentUrl, SupportedFileType.PDF);
-            currentUrl = URL.createObjectURL(blob);
+            /**
+             * Handle case for PDF
+             */
+            if (item.type === MediaFormat.PDF) {
+              const blob = base64toBlob(currentUrl, SupportedFileType.PDF);
+              currentUrl = URL.createObjectURL(blob);
+            }
+          } else {
+            /**
+             * Use value from url
+             */
+            currentUrl = mediaItem.values[currentIndex] as string;
           }
-        } else {
+
           /**
-           * Use value from url
+           * Remove toolbar for PDF default reader
            */
-          currentUrl = mediaItem.values[currentIndex] as string;
-        }
+          if (item.type === MediaFormat.PDF && !isEnablePdfToolbar) {
+            currentUrl += '#toolbar=0';
+          }
 
-        /**
-         * Remove toolbar for PDF default reader
-         */
-        if (item.type === MediaFormat.PDF && !isEnablePdfToolbar) {
-          currentUrl += '#toolbar=0';
+          return {
+            type: item.type,
+            url: currentUrl,
+            field: item.field,
+          };
         }
-
+      } catch (e) {
+        /* no console is allowed */
         return {
-          type: item.type,
-          url: currentUrl,
-          field: item.field,
+          type: null,
+          error: e,
         };
       }
     }


### PR DESCRIPTION
* If fetching media fails and a crash happens catch it return null.

* Original issue is receiving a 500 http error when the druid DB fails to respond quick enough within 5000 ms then code throws a 500.


Untested so far, I am figuring out how to test this with my Grafana setup. WIP hoping it helps developers find the issue and fix it faster (just have druid not respond fast from some operational issues / ram shortage and this should show the images failing to load after one fetch fails and a 500 is seen in the inspector).